### PR TITLE
Update readme with instructions for installing docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,16 @@ This is the server part of the CoLab chat app.
 
 #### Set up
 
-To install the dependencies run `pip3 install -r requirements.txt`
-Note that you need to create a database with `python3 ./web/manage.py create_db` to be able
+To install the python dependencies run `pip install -r requirements.txt`
+Note that you need to create a database with `python ./web/manage.py create_db` to be able
 to store user data.
+
+You will also need to install docker and docker-compose. For example on Ubuntu:
+```
+sudo apt install docker
+sudo apt install docker-compose
+sudo usermod -aG docker $USER
+```
 
 
 ##### Run
@@ -18,4 +25,4 @@ are to come. In addition to `production` we will support `development` and `test
 
 ###### Lint
 
-To perform lint checking, run `python3 ./web/manage.py lint`.
+To perform lint checking, run `python ./web/manage.py lint`.


### PR DESCRIPTION
Update readme with instructions for installing docker. I had to add my user to the `docker` user group to get the appropriate permissions for `docker-compose`.

Also removed the "3" from python and pip commands as that is a platform specific detail. It also isn't required when working in a virtualenv.