### PR TITLE
Add development environment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,15 @@ sudo usermod -aG docker $USER
 
 ##### Run
 
-To start the webserver: `docker-compose up -d`.
-The page is served to `loacalhost:80` running with `production` settings. More generic settings
-are to come. In addition to `production` we will support `development` and `testing`.
+To start the webserver use `colab.py`.
+To run in production mode you can either use `./colab.py` or `./colab.py -r 0` or `./colab.py --run 0`.
+To run in development mode you can either use `./colab.py -r 1` or `./colab.py --run 1`.
+To run in detached mode add `-d` or `--detached`.
+To stop use `./colab.py -s` or `./colab.py --stop`.
 
+Testing environment support is to come.
+ 
+The page is served to `loacalhost:80`.
 
 ###### Lint
 

--- a/colab.py
+++ b/colab.py
@@ -9,44 +9,57 @@ parser = argparse.ArgumentParser(description='CoLab Startup')
 parser.add_argument('-r', '--run', type=int, choices=[0, 1, 2],
                     help='set run type: 0=production, 1=development, 2=testing', default=0)
 parser.add_argument('-d', '--detach', action='store_true', help='start docker in detached mode')
+parser.add_argument('-s', '--stop', action='store_true', help='stop docker containers')
+parser.add_argument('-b', '--build', action='store_true', help='build docker containers')
 args = parser.parse_args()
 
 
-# ---------------------------------
-# Set up process for docker compose
-# ---------------------------------
-process_list = ["docker-compose", "-f", "docker-compose.yaml"]
 
+# -------------------------------
+# Check if colab is to be stopped
+# ------------------------------
+if args.stop:
+  # TODO need to check if other commands have been set
+  process_list = ["docker-compose", "stop"]
+elif args.build:
+  # TODO need to check if other commands have been set
+  process_list = ["docker-compose", "build"]
+else:
+  # ---------------------------------
+  # Set up process for docker compose
+  # ---------------------------------
+  process_list = ["docker-compose", "-f", "docker-compose.yaml"]
+ 
 
-# -----------------------------
-# Select correct docker-compose
-# -----------------------------
-run_type = args.run
-if run_type == 1:
+  # -----------------------------
+  # Select correct docker-compose
+  # -----------------------------
+  run_type = args.run
+  if run_type == 1:
     print("Running in development mode")
     development_flags = ["-f",  "docker-compose.development.yaml"]
     process_list.extend(development_flags)
-elif run_type == 2:
+  elif run_type == 2:
     print("Running in testing mode")
-else:
+  else:
     print("Running in production mode")
     production_flags = ["-f",  "docker-compose.production.yaml"]
     process_list.extend(production_flags)
 
-# ---------
-# Up docker
-# ---------
-process_list.append("up")
+  # ---------
+  # Up docker
+  # ---------
+  process_list.append("up")
 
-# ---------------------------------------
-# Add detached mode
-# ---------------------------------------
-detach_mode = args.detach
-if detach_mode:
+  # ---------------------------------------
+  # Add detached mode
+  # ---------------------------------------
+  detach_mode = args.detach
+  if detach_mode:
     process_list.append("-d")
 
 # ----------------
 # Run docker
 # ----------------
-print
 call(process_list)
+

--- a/colab.py
+++ b/colab.py
@@ -5,30 +5,48 @@ from subprocess import call
 
 parser = argparse.ArgumentParser(description='CoLab Startup')
 
-# Add acceptable arguments
-parser.add_argument('-r', '--run',type=int, choices=[0, 1, 2], help='set run type: 0=production, 1=development, 2=testing', default=0)
+# Add acceptable arguments and parse
+parser.add_argument('-r', '--run', type=int, choices=[0, 1, 2],
+                    help='set run type: 0=production, 1=development, 2=testing', default=0)
 parser.add_argument('-d', '--detach', action='store_true', help='start docker in detached mode')
-
-
-# Get the arguments
 args = parser.parse_args()
 
-# -------------------------------------------
-# Act on the arguments
-# ------------------------------------------
 
-# Check if we should run in detached mode
-detach_mode = args.detach
-detach_mode_specifier = "-d" if detach_mode else ""
+# ---------------------------------
+# Set up process for docker compose
+# ---------------------------------
+process_list = ["docker-compose", "-f", "docker-compose.yaml"]
 
-# Set up sub system call
+
+# -----------------------------
+# Select correct docker-compose
+# -----------------------------
 run_type = args.run
 if run_type == 1:
-  print("Running in development mode")
-  call(["docker-compose", "-f", "docker-compose.yaml", "-f", "docker-compose.development.yaml", "up", detach_mode_specifier])
+    print("Running in development mode")
+    development_flags = ["-f",  "docker-compose.development.yaml"]
+    process_list.extend(development_flags)
 elif run_type == 2:
-  print("Running in testing mode")
+    print("Running in testing mode")
 else:
-  print("Running in production mode")
-  call(["docker-compose", "-f", "docker-compose.yaml", "-f", "docker-compose.production.yaml", "up", detach_mode_specifier])
+    print("Running in production mode")
+    production_flags = ["-f",  "docker-compose.production.yaml"]
+    process_list.extend(production_flags)
 
+# ---------
+# Up docker
+# ---------
+process_list.append("up")
+
+# ---------------------------------------
+# Add detached mode
+# ---------------------------------------
+detach_mode = args.detach
+if detach_mode:
+    process_list.append("-d")
+
+# ----------------
+# Run docker
+# ----------------
+print
+call(process_list)

--- a/colab.py
+++ b/colab.py
@@ -7,7 +7,7 @@ parser = argparse.ArgumentParser(description='CoLab Startup')
 
 # Add acceptable arguments
 parser.add_argument('-r', '--run',type=int, choices=[0, 1, 2], help='set run type: 0=production, 1=development, 2=testing', default=0)
-parser.add_argument('-d', '--detach', help='start docker in detached mode')
+parser.add_argument('-d', '--detach', action='store_true', help='start docker in detached mode')
 
 
 # Get the arguments
@@ -18,17 +18,17 @@ args = parser.parse_args()
 # ------------------------------------------
 
 # Check if we should run in detached mode
-
-
+detach_mode = args.detach
+detach_mode_specifier = "-d" if detach_mode else ""
 
 # Set up sub system call
 run_type = args.run
 if run_type == 1:
   print("Running in development mode")
-  call(["docker-compose", "-f", "docker-compose.yaml", "-f", "docker-compose.development.yaml", "up"])
+  call(["docker-compose", "-f", "docker-compose.yaml", "-f", "docker-compose.development.yaml", "up", detach_mode_specifier])
 elif run_type == 2:
   print("Running in testing mode")
 else:
   print("Running in production mode")
-  call(["docker-compose", "-f", "docker-compose.yaml", "-f", "docker-compose.production.yaml", "up"])
+  call(["docker-compose", "-f", "docker-compose.yaml", "-f", "docker-compose.production.yaml", "up", detach_mode_specifier])
 

--- a/colab.py
+++ b/colab.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python 
+
+import argparse
+from subprocess import call
+
+parser = argparse.ArgumentParser(description='CoLab Startup')
+
+# Add acceptable arguments
+parser.add_argument('-r', '--run',type=int, choices=[0, 1, 2], help='set run type: 0=production, 1=development, 2=testing', default=0)
+parser.add_argument('-d', '--detach', help='start docker in detached mode')
+
+
+# Get the arguments
+args = parser.parse_args()
+
+# -------------------------------------------
+# Act on the arguments
+# ------------------------------------------
+
+# Check if we should run in detached mode
+
+
+
+# Set up sub system call
+run_type = args.run
+if run_type == 1:
+  print("Running in development mode")
+  call(["docker-compose", "-f", "docker-compose.yaml", "-f", "docker-compose.development.yaml", "up"])
+elif run_type == 2:
+  print("Running in testing mode")
+else:
+  print("Running in production mode")
+  call(["docker-compose", "-f", "docker-compose.yaml", "-f", "docker-compose.production.yaml", "up"])
+

--- a/docker-compose.development.yaml
+++ b/docker-compose.development.yaml
@@ -1,0 +1,6 @@
+version: '2'
+
+services:
+ web:
+   environment:
+     COLAB_CONFIG: 'development'

--- a/docker-compose.production.yaml
+++ b/docker-compose.production.yaml
@@ -1,0 +1,6 @@
+version: '2'
+
+services:
+ web:
+   environment:
+     COLAB_CONFIG: 'production'

--- a/web/colab_server/__init__.py
+++ b/web/colab_server/__init__.py
@@ -3,6 +3,8 @@ from flask_bootstrap import Bootstrap
 from flask_mail import Mail
 from flask_sqlalchemy import SQLAlchemy
 from flask_sse import sse
+from flask_debugtoolbar import DebugToolbarExtension
+
 
 # ----------------
 # Flask extensions
@@ -10,6 +12,7 @@ from flask_sse import sse
 db = SQLAlchemy()
 bootstrap = Bootstrap()
 mail = Mail()
+debug_toolbar = DebugToolbarExtension()
 
 
 def create_app(configuration):
@@ -28,6 +31,7 @@ def create_app(configuration):
     db.init_app(app)
     mail.init_app(app)
     bootstrap.init_app(app)
+    debug_toolbar.init_app(app)
 
     # --------------------
     # Authentication setup

--- a/web/colab_server/__init__.py
+++ b/web/colab_server/__init__.py
@@ -20,6 +20,7 @@ def create_app(configuration):
         raise ValueError("Missing configuration for CoLab")
     app = Flask(__name__)
     app.config.from_object(configuration)
+    print("Set up application with configuration for {}.".format(configuration.name))
 
     # ---------------------------
     # Initialize flask extensions

--- a/web/config.py
+++ b/web/config.py
@@ -90,6 +90,7 @@ class Config:
 class DevelopmentConfig(Config):
     name = "development"
     DEBUG = True
+    DEBUG_TB_INTERCEPT_REDIRECTS = False
 
 
 class ProductionConfig(Config):

--- a/web/config.py
+++ b/web/config.py
@@ -28,6 +28,8 @@ def secure_config(cls):
 # -------------------------------------------
 @secure_config
 class Config:
+    _NAME = ""
+
     DEBUG = False
     TESTING = False
 
@@ -84,16 +86,23 @@ class Config:
 
     REDIS_URL = "redis://redis:6379"
 
+    @property
+    def name(self):
+        return self._NAME
+
 
 class DevelopmentConfig(Config):
+    _NAME = "development"
     DEBUG = True
 
 
 class ProductionConfig(Config):
+    _NAME = "production"
     pass
 
 
 class TestingConfig(Config):
+    _NAME = "testing"
     TESTING = True
     SQLALCHEMY_DATABASE_URI = 'sqlite://'
 
@@ -106,12 +115,12 @@ def create_configuration(configuration_type=None):
     :param configuration_type: The type of configuration as a string
     :return: a configuration class
     """
-    config = {'development': DevelopmentConfig,
-              'production': ProductionConfig,
-              'testing': TestingConfig}
+    config = {DevelopmentConfig.name: DevelopmentConfig,
+              ProductionConfig.name: ProductionConfig,
+              TestingConfig.name: TestingConfig}
 
     if configuration_type is None:
-        configuration_name = os.environ.get('COLAB_CONFIG', 'production')
+        configuration_name = os.environ.get('COLAB_CONFIG', ProductionConfig.name)
         return config[configuration_name]
     elif configuration_type in config:
         return config[configuration_type]

--- a/web/config.py
+++ b/web/config.py
@@ -28,7 +28,7 @@ def secure_config(cls):
 # -------------------------------------------
 @secure_config
 class Config:
-    _NAME = ""
+    name = ""
 
     DEBUG = False
     TESTING = False
@@ -71,7 +71,7 @@ class Config:
 
     # ---------------------
     # Flask User
-    # --------------------
+    # ---------------------
     USER_APP_NAME = APP_NAME
     USER_ENABLE_CHANGE_PASSWORD = True
     USER_ENABLE_CHANGE_USERNAME = False
@@ -86,23 +86,19 @@ class Config:
 
     REDIS_URL = "redis://redis:6379"
 
-    @property
-    def name(self):
-        return self._NAME
-
 
 class DevelopmentConfig(Config):
-    _NAME = "development"
+    name = "development"
     DEBUG = True
 
 
 class ProductionConfig(Config):
-    _NAME = "production"
+    name = "production"
     pass
 
 
 class TestingConfig(Config):
-    _NAME = "testing"
+    name = "testing"
     TESTING = True
     SQLALCHEMY_DATABASE_URI = 'sqlite://'
 
@@ -123,7 +119,7 @@ def create_configuration(configuration_type=None):
         configuration_name = os.environ.get('COLAB_CONFIG', ProductionConfig.name)
         return config[configuration_name]
     elif configuration_type in config:
-        return config[configuration_type]
+        return config[configuration_type.name()]
     else:
         raise ValueError("The colab configuration {} is not known. "
                          "Please select production, development or testing or"

--- a/web/config.py
+++ b/web/config.py
@@ -120,7 +120,7 @@ def create_configuration(configuration_type=None):
         configuration_name = os.environ.get('COLAB_CONFIG', ProductionConfig.name)
         return config[configuration_name]
     elif configuration_type in config:
-        return config[configuration_type.name()]
+        return config[configuration_type.name]
     else:
         raise ValueError("The colab configuration {} is not known. "
                          "Please select production, development or testing or"

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,4 +1,5 @@
 Flask
+Flask-Debugtoolbar
 Flask-User<0.7
 Flask-SQLAlchemy==2.1
 Flask-Bootstrap==3.3.5.7


### PR DESCRIPTION
This PR adds a development option which brings up the `Flask-Development Toolbar`

We still need to add good logging and we need to provide a testing configuration.

## To test

#### Run production

1. Run `./colab.py -d`
  *  Confirm that colab is being served and that there is no debug tool bar on the side of colab
2. Run `./colab.py -s` 
  * Confirm that colab is not being served any longer. Confirm that all docker instances have been stopped.

### Run development

1. Run `./colab.py -r 1 -d`
  *  Confirm that colab is being served and that there is a debug tool bar on the side of colab
2. Run `./colab.py -s` 
  * Confirm that colab is not being served any longer. Confirm that all docker instances have been stopped.
