### PR TITLE
Use kafkacat to check Kafka is ready before starting web app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ ENV/
 # CoLab files
 web/colab_server.sqlite
 web/secure_config.ini
+web/web_log.txt

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -16,6 +16,20 @@ RUN cd /tmp && \
 
 RUN apt-get -y install python3-cffi python3-dev
 
+WORKDIR /build
+
+ENV BUILD_PACKAGES "build-essential git curl zlib1g-dev python"
+RUN apt-get update -y
+RUN apt-get install $BUILD_PACKAGES -y
+RUN git clone https://github.com/edenhill/kafkacat.git
+RUN cd kafkacat && \
+    ./bootstrap.sh && \
+    make install && \
+    cd .. && rm -rf kafkacat
+RUN AUTO_ADDED_PACKAGES=`apt-mark showauto`
+RUN apt-get remove --purge -y $BUILD_PACKAGES $AUTO_ADDED_PACKAGES
+RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 #  Transfer code
 RUN mkdir /colab
 ADD . /colab

--- a/web/boot.sh
+++ b/web/boot.sh
@@ -1,5 +1,15 @@
 #!/bin/sh
 
-# Wait 15 seconds to make sure Kafka is ready before starting
-sleep 15
+# Wait for Kafka to be ready before starting the web app
+kafkacat -b kafka -L
+OUT=$?
+i="0"
+while [ $OUT -ne 0 -a  $i != 10  ]; do
+   echo "Waiting for Kafka to be ready"
+   sleep 1
+   kafkacat -b kafka -L
+   OUT=$?
+   i=$[$i+1]
+done
+
 gunicorn wsgi:application --worker-class gevent --bind 0.0.0.0:8000

--- a/web/boot.sh
+++ b/web/boot.sh
@@ -4,9 +4,8 @@
 kafkacat -b kafka -L
 OUT=$?
 i="0"
-while [ $OUT -ne 0 -a  $i != 10  ]; do
+while [ $OUT -ne 0 -a  $i -ne 10  ]; do
    echo "Waiting for Kafka to be ready"
-   sleep 1
    kafkacat -b kafka -L
    OUT=$?
    i=$[$i+1]

--- a/web/colab_server/flask_sse_kafka.py
+++ b/web/colab_server/flask_sse_kafka.py
@@ -61,7 +61,6 @@ class ServerSentEventsBlueprint(Blueprint):
         self.consumer.subscribe([TOPIC_NAME])
         running = True
         while running:
-            current_app.logger.debug("polling consumer")
             try:
                 msg = self.consumer.poll(1.0)
                 if msg is None:


### PR DESCRIPTION
Closes #19 

Adds kafkacat (https://github.com/edenhill/kafkacat) to the web container so that it can be used to check when the Kafka brokers are ready for the web app to start.