### PR TITLE
Add units tests for Message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,19 @@
 language: python
+
+env:
+  - FLAKE=true
+  - FLAKE=false
+matrix:
+  allow_failures:
+    - env: FLAKE=true
 python:
   - "3.5"
 before_install: sudo bash travis.sh
 # install dependencies
-install: "pip install -r ./web/requirements.txt"
+install:
+  - pip install -r ./web/requirements.txt
+  - pip install pytest
 # run linter
-script: python ./web/manage.py lint
+script:
+  - if $FLAKE ; then python ./web/manage.py lint ; fi
+  - python colab.py -r tests

--- a/README.md
+++ b/README.md
@@ -22,16 +22,19 @@ sudo usermod -aG docker $USER
 ##### Run
 
 To start the webserver use `colab.py`.
-To run in production mode you can either use `./colab.py` or `./colab.py -r 0` or `./colab.py --run 0`.
-To run in development mode you can either use `./colab.py -r 1` or `./colab.py --run 1`.
+To run in production mode you can either use `./colab.py` or `./colab.py -r prod` or `./colab.py --run prod`.
+To run in development mode you can either use `./colab.py -r dev` or `./colab.py --run dev`.
 To run in detached mode add `-d` or `--detached`.
 To stop use `./colab.py -s` or `./colab.py --stop`.
 
 If you don't stop the containers gracefully you may see the error "A broker is already registered on the path /brokers/ids/1." when restarting. This can be fixed by `docker-compose kill` then bring back up as normal.
 
-Testing environment support is to come.
- 
 The page is served to `localhost:80`.
+
+Unit tests can be run with `./colab.py -r tests` after installing pytest with
+```
+pip install pytest
+```
 
 ###### Lint
 

--- a/colab.py
+++ b/colab.py
@@ -7,8 +7,7 @@ parser = argparse.ArgumentParser(description='CoLab Startup')
 
 # Add acceptable arguments and parse
 parser.add_argument('-r', '--run', type=str, choices=['prod', 'dev', 'tests'],
-                    help='set run type: 0=production, 1=development, 2=testing',
-                    default=0)
+                    default='prod')
 parser.add_argument('-d', '--detach', action='store_true',
                     help='start docker in detached mode')
 parser.add_argument('-s', '--stop', action='store_true',

--- a/colab.py
+++ b/colab.py
@@ -6,11 +6,15 @@ from subprocess import call
 parser = argparse.ArgumentParser(description='CoLab Startup')
 
 # Add acceptable arguments and parse
-parser.add_argument('-r', '--run', type=int, choices=[0, 1, 2],
-                    help='set run type: 0=production, 1=development, 2=testing', default=0)
-parser.add_argument('-d', '--detach', action='store_true', help='start docker in detached mode')
-parser.add_argument('-s', '--stop', action='store_true', help='stop docker containers')
-parser.add_argument('-b', '--build', action='store_true', help='build docker containers')
+parser.add_argument('-r', '--run', type=str, choices=['prod', 'dev', 'tests'],
+                    help='set run type: 0=production, 1=development, 2=testing',
+                    default=0)
+parser.add_argument('-d', '--detach', action='store_true',
+                    help='start docker in detached mode')
+parser.add_argument('-s', '--stop', action='store_true',
+                    help='stop docker containers')
+parser.add_argument('-b', '--build', action='store_true',
+                    help='build docker containers')
 args = parser.parse_args()
 
 # -------------------------------
@@ -32,11 +36,11 @@ else:
     # Select correct docker-compose
     # -----------------------------
     run_type = args.run
-    if run_type == 1:
+    if run_type == 'dev':
         print("Running in development mode")
         development_flags = ["-f", "docker-compose.development.yaml"]
         process_list.extend(development_flags)
-    elif run_type == 2:
+    elif run_type == 'tests':
         print("Running in testing mode")
     else:
         print("Running in production mode")

--- a/colab.py
+++ b/colab.py
@@ -41,7 +41,10 @@ else:
         development_flags = ["-f", "docker-compose.development.yaml"]
         process_list.extend(development_flags)
     elif run_type == 'tests':
+        import pytest
         print("Running in testing mode")
+        pytest.main()
+        exit()
     else:
         print("Running in production mode")
         production_flags = ["-f", "docker-compose.production.yaml"]

--- a/tests/env.py
+++ b/tests/env.py
@@ -1,0 +1,11 @@
+import sys
+import os
+
+# append module root directory to sys.path
+sys.path.append(
+    os.path.dirname(
+        os.path.dirname(
+            os.path.abspath(__file__)
+        )
+    )
+)

--- a/tests/env.py
+++ b/tests/env.py
@@ -4,8 +4,6 @@ import os
 # append module root directory to sys.path
 sys.path.append(
     os.path.dirname(
-        os.path.dirname(
-            os.path.abspath(__file__)
-        )
+        os.path.abspath(__file__)
     )
 )

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -36,7 +36,7 @@ def test_message_non_string_author_fails():
                     datetime.now(), 'test_topic', 'message test string')
 
 
-def test_message_get_author():
+def test_message_get_author_matches_initialised_author():
     author = 'test_author'
     message = FakeMessage(author, 'last_test_author', datetime.now(),
                           datetime.now(), 'test_topic', 'message test string')
@@ -50,7 +50,7 @@ def test_message_non_string_last_author_fails():
                     datetime.now(), 'test_topic', 'message test string')
 
 
-def test_message_get_last_author():
+def test_message_get_last_author_matches_initialised_last_author():
     last_author = 'last_test_author'
     message = FakeMessage('test_author', last_author, datetime.now(),
                           datetime.now(), 'test_topic', 'message test string')
@@ -64,7 +64,7 @@ def test_message_non_datetime_created_fails():
                     datetime.now(), 'test_topic', 'message test string')
 
 
-def test_message_get_time_created():
+def test_message_get_time_created_matches_initialised_time():
     time_created = datetime.now()
     message = FakeMessage('test_author', 'test_last_author', time_created,
                           datetime.now(), 'test_topic', 'message test string')
@@ -78,21 +78,21 @@ def test_message_non_datetime_last_modified_fails():
                     time_modified, 'test_topic', 'message test string')
 
 
-def test_message_get_time_modified():
+def test_message_get_time_modified_matches_initialised_time():
     time_modified = datetime.now()
     message = FakeMessage('test_author', 'test_last_author', datetime.now(),
                           time_modified, 'test_topic', 'message test string')
     assert message.get_time_last_modified() == time_modified
 
 
-def test_message_get_message():
+def test_message_get_message_matches_initialised_message():
     message_contents = 'message test string'
     message = FakeMessage('test_author', 'test_last_author', datetime.now(),
                           datetime.now(), 'test_topic', message_contents)
     assert message.get_raw_message() == message_contents
 
 
-def test_message_get_topic():
+def test_message_get_topic_matches_initialised_topic():
     topic = 'test_topic'
     message = FakeMessage('test_author', 'test_last_author', datetime.now(),
                           datetime.now(), topic, 'message test string')

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,0 +1,57 @@
+import env
+import pytest
+from datetime import datetime
+from web.colab_server.messages.message import Message, MessageType
+from web.colab_server.messages.message_text import TextMessage
+from web.colab_server.messages.message_image import ImageMessage
+
+
+class MockMessage(Message):
+    def __init__(self, author, last_author, time_created, time_last_modified,
+                 topic, message):
+        super(MockMessage, self).__init__(
+            author=author,
+            last_author=last_author,
+            time_created=time_created,
+            time_last_modified=time_last_modified,
+            topic=topic, message=message)
+        self._message_type = MessageType.MOCK
+
+    def serialize(self):
+        pass
+
+    def _do_create_html_message(self):
+        pass
+
+
+def test_message_creation():
+    MockMessage('test_author', 'last_test_author', datetime.now(),
+                datetime.now(), 'message test string', 'test_topic')
+
+
+def test_message_non_string_author_fails():
+    author = 42
+    with pytest.raises(ValueError):
+        MockMessage(author, 'last_test_author', datetime.now(),
+                    datetime.now(), 'message test string', 'test_topic')
+
+
+def test_message_get_author():
+    author = 'test_author'
+    message = MockMessage(author, 'last_test_author', datetime.now(),
+                          datetime.now(), 'message test string', 'test_topic')
+    assert message.get_author() == author
+
+
+def test_message_non_string_last_author_fails():
+    last_author = 42
+    with pytest.raises(ValueError):
+        MockMessage('test_author', last_author, datetime.now(),
+                    datetime.now(), 'message test string', 'test_topic')
+
+
+def test_message_get_last_author():
+    last_author = 'last_test_author'
+    message = MockMessage('test_author', last_author, datetime.now(),
+                          datetime.now(), 'message test string', 'test_topic')
+    assert message.get_last_author() == last_author

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -2,8 +2,6 @@ import env
 import pytest
 from datetime import datetime
 from web.colab_server.messages.message import Message, MessageType
-from web.colab_server.messages.message_text import TextMessage
-from web.colab_server.messages.message_image import ImageMessage
 
 
 class FakeMessage(Message):

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -6,10 +6,10 @@ from web.colab_server.messages.message_text import TextMessage
 from web.colab_server.messages.message_image import ImageMessage
 
 
-class MockMessage(Message):
+class FakeMessage(Message):
     def __init__(self, author, last_author, time_created, time_last_modified,
                  topic, message):
-        super(MockMessage, self).__init__(
+        super(FakeMessage, self).__init__(
             author=author,
             last_author=last_author,
             time_created=time_created,
@@ -25,33 +25,76 @@ class MockMessage(Message):
 
 
 def test_message_creation():
-    MockMessage('test_author', 'last_test_author', datetime.now(),
-                datetime.now(), 'message test string', 'test_topic')
+    FakeMessage('test_author', 'last_test_author', datetime.now(),
+                datetime.now(), 'test_topic', 'message test string')
 
 
 def test_message_non_string_author_fails():
     author = 42
     with pytest.raises(ValueError):
-        MockMessage(author, 'last_test_author', datetime.now(),
-                    datetime.now(), 'message test string', 'test_topic')
+        FakeMessage(author, 'last_test_author', datetime.now(),
+                    datetime.now(), 'test_topic', 'message test string')
 
 
 def test_message_get_author():
     author = 'test_author'
-    message = MockMessage(author, 'last_test_author', datetime.now(),
-                          datetime.now(), 'message test string', 'test_topic')
+    message = FakeMessage(author, 'last_test_author', datetime.now(),
+                          datetime.now(), 'test_topic', 'message test string')
     assert message.get_author() == author
 
 
 def test_message_non_string_last_author_fails():
     last_author = 42
     with pytest.raises(ValueError):
-        MockMessage('test_author', last_author, datetime.now(),
-                    datetime.now(), 'message test string', 'test_topic')
+        FakeMessage('test_author', last_author, datetime.now(),
+                    datetime.now(), 'test_topic', 'message test string')
 
 
 def test_message_get_last_author():
     last_author = 'last_test_author'
-    message = MockMessage('test_author', last_author, datetime.now(),
-                          datetime.now(), 'message test string', 'test_topic')
+    message = FakeMessage('test_author', last_author, datetime.now(),
+                          datetime.now(), 'test_topic', 'message test string')
     assert message.get_last_author() == last_author
+
+
+def test_message_non_datetime_created_fails():
+    time_created = 42
+    with pytest.raises(ValueError):
+        FakeMessage('test_author', 'test_last_author', time_created,
+                    datetime.now(), 'test_topic', 'message test string')
+
+
+def test_message_get_time_created():
+    time_created = datetime.now()
+    message = FakeMessage('test_author', 'test_last_author', time_created,
+                          datetime.now(), 'test_topic', 'message test string')
+    assert message.get_time_created() == time_created
+
+
+def test_message_non_datetime_last_modified_fails():
+    time_modified = 42
+    with pytest.raises(ValueError):
+        FakeMessage('test_author', 'test_last_author', datetime.now(),
+                    time_modified, 'test_topic', 'message test string')
+
+
+def test_message_get_time_modified():
+    time_modified = datetime.now()
+    message = FakeMessage('test_author', 'test_last_author', datetime.now(),
+                          time_modified, 'test_topic', 'message test string')
+    assert message.get_time_last_modified() == time_modified
+
+
+def test_message_get_message():
+    message_contents = 'message test string'
+    message = FakeMessage('test_author', 'test_last_author', datetime.now(),
+                          datetime.now(), 'test_topic', message_contents)
+    assert message.get_raw_message() == message_contents
+
+
+def test_message_get_topic():
+    topic = 'test_topic'
+    message = FakeMessage('test_author', 'test_last_author', datetime.now(),
+                          datetime.now(), topic, 'message test string')
+    assert message.get_topic() == topic
+

--- a/tests/test_serialise_deserialise.py
+++ b/tests/test_serialise_deserialise.py
@@ -1,8 +1,0 @@
-import env
-import pytest
-from web.colab_server.streaming.avroserialiser import AvroSerialiser
-from web.colab_server.streaming.avrodeserialiser import AvroDeserialiser
-
-
-def test_fails():
-    assert False

--- a/tests/test_serialise_deserialise.py
+++ b/tests/test_serialise_deserialise.py
@@ -1,0 +1,8 @@
+import env
+import pytest
+from web.colab_server.streaming.avroserialiser import AvroSerialiser
+from web.colab_server.streaming.avrodeserialiser import AvroDeserialiser
+
+
+def test_fails():
+    assert False

--- a/web/colab_server/__init__.py
+++ b/web/colab_server/__init__.py
@@ -3,7 +3,6 @@ import logging
 from flask_bootstrap import Bootstrap
 from flask_mail import Mail
 from flask_sqlalchemy import SQLAlchemy
-from .flask_sse_kafka import sse
 from flask_debugtoolbar import DebugToolbarExtension
 
 # ----------------
@@ -16,6 +15,9 @@ debug_toolbar = DebugToolbarExtension()
 
 
 def create_app(configuration):
+    from .flask_sse_kafka import sse
+    # import sse here to avoid starting consumer during unit tests
+
     # ------------------------
     # Set up colab_server configuration
     # ------------------------

--- a/web/colab_server/main_view.py
+++ b/web/colab_server/main_view.py
@@ -22,5 +22,5 @@ def index():
 def publish_hello():
     sse.publish(
         TextMessage('author', 'last_author', datetime.now(), datetime.now(),
-                    'test_avro_topic', 'Life is good!'))
+                    'Life is good!', 'test_avro_topic'))
     return "Message sent!"

--- a/web/colab_server/messages/message.py
+++ b/web/colab_server/messages/message.py
@@ -14,7 +14,7 @@ class MessageType(Enum):
 
 class Message(metaclass=ABCMeta):
     def __init__(self, author, last_author, time_created, time_last_modified,
-                 message, topic, html=None):
+                 topic, message, html=None):
         if not isinstance(time_created, datetime):
             raise ValueError(
                 "time_stamp: Expected a datetime object, got {}".format(

--- a/web/colab_server/messages/message.py
+++ b/web/colab_server/messages/message.py
@@ -9,6 +9,7 @@ class MessageType(Enum):
     PYTHON = 2
     R = 3
     IMAGE = 4
+    MOCK = 99
 
 
 class Message(metaclass=ABCMeta):

--- a/web/colab_server/messages/message_image.py
+++ b/web/colab_server/messages/message_image.py
@@ -13,7 +13,7 @@ def get_blob_from_file(file_handle):
 
 class ImageMessage(Message):
     def __init__(self, author, last_author, time_created, time_last_modified,
-                 message, topic, html=None):
+                 topic, message, html=None):
         if not isinstance(message, bytes):
             raise RuntimeError("The message has to be bytes")
         super(ImageMessage, self).__init__(

--- a/web/colab_server/messages/message_text.py
+++ b/web/colab_server/messages/message_text.py
@@ -3,7 +3,7 @@ from .message import (Message, MessageType)
 
 class TextMessage(Message):
     def __init__(self, author, last_author, time_created, time_last_modified,
-                 topic, message):
+                 message, topic):
         super(TextMessage, self).__init__(
             author=author,
             last_author=last_author,


### PR DESCRIPTION
Closes #30 

These are the first unit tests, so I've added how to run them to the readme. It also required tweaking the app `__init__` to avoid trying to connect to Kafka unless the app is actually being created.
Travis now also runs the unit tests.