### PR TITLE
Fix SSE connection timeout

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -30,6 +30,8 @@ http {
    # Define the timeout value for keep-alive connections with the client
    keepalive_timeout  65;
 
+   proxy_read_timeout  24h;
+
    #gzip  on;
 
    include /etc/nginx/conf.d/*.conf;

--- a/web/colab_server/flask_sse_kafka.py
+++ b/web/colab_server/flask_sse_kafka.py
@@ -15,7 +15,7 @@ def delivery_callback(err, msg):
     if err:
         current_app.logger.error('%% Message failed delivery: %s\n' % err)
     else:
-        current_app.logger.error('%% Message delivered to %s [%d]\n' %
+        current_app.logger.debug('%% Message delivered to %s [%d]\n' %
                                  (msg.topic(), msg.partition()))
 
 


### PR DESCRIPTION
Closes #31 

SSE connection was being closed after 60 seconds of inactivity. Changed nginx configuration to fix.